### PR TITLE
test: Fix timing-dependent test

### DIFF
--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -104,6 +104,8 @@ suite('Extension Test Suite', () => {
       'workbench.action.files.newUntitledFile'
     )
 
+    await waitTabs(1)
+
     // open preview
     await vscode.commands.executeCommand(
       'markdown.showPreview',

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -13,7 +13,7 @@ suite('Extension Test Suite', () => {
           clearInterval(id)
           resolve()
         }
-      }, 10)
+      }, 50)
     })
   }
   function waitTabs(num: number): Promise<void> {
@@ -23,7 +23,7 @@ suite('Extension Test Suite', () => {
           clearInterval(id)
           resolve()
         }
-      }, 10)
+      }, 50)
     })
   }
   function waitTabsNot(num: number): Promise<void> {
@@ -33,7 +33,7 @@ suite('Extension Test Suite', () => {
           clearInterval(id)
           resolve()
         }
-      }, 10)
+      }, 50)
     })
   }
   function waitText(): Promise<string> {
@@ -54,7 +54,7 @@ suite('Extension Test Suite', () => {
           clearInterval(id)
           resolve()
         }
-      }, 10)
+      }, 50)
     })
   }
   // close all tabGroups each tests in before

--- a/src/test/web/index.ts
+++ b/src/test/web/index.ts
@@ -7,7 +7,7 @@ export function run(): Promise<void> {
     mocha.setup({
       ui: 'tdd',
       reporter: undefined,
-      timeout: 5000
+      timeout: 1000 * 10
     })
     typeof importAll === 'function' && (await importAll())
 


### PR DESCRIPTION
1. Open a new text tab.
2. Wait until the text tab is opened.
3. Open the preview tab.

Previously, there were cases where the preview tab was opened before the text
tab was opened.
